### PR TITLE
Add wallet safety note

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ nano wallet.json
   * `private-key-here`: Privatekey with `B64` format
   * `octxxxxxxxx...`: Octra address starting with `oct...`
 
+**Safety note**
+
+Do not share your `wallet.json`, private key, seed phrase, PIN, or decrypted wallet material in Discord, issues, pull requests, screenshots, or support chats. If you need someone to help debug setup, share only redacted errors, public addresses, and the non-secret shape of the file.
+
+For an optional AI-assisted checklist focused on Octra wallet/client safety, [ChainForge](https://github.com/codegraphtheory/chainforge) includes Octra-specific review guidance for `octra_pre_client`, `webcli`, wallet generation, RPC use, and private-key handling.
 
 **4. Run CLI**
 ```bash


### PR DESCRIPTION
Hi, thanks for the Octra guide.

I added a short safety note next to the `wallet.json` setup step. That is the point where new users are most likely to handle private key material, so I think it is worth making the warning explicit in the guide itself.

The note tells users not to share wallet files, private keys, seed phrases, PINs, or decrypted wallet material in support channels, screenshots, issues, or PRs. I also added ChainForge as an optional checklist for reviewing Octra wallet and client workflows, since it now has Octra-specific safety guidance.

Checked locally:

- `git diff --check`
- confirmed the wallet safety note and ChainForge link are present
